### PR TITLE
fix: Update trap to return original exit signal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ function log() {
   echo "$(date -u) $*"
 }
 
-trap 'log "There was a problem. Please take a look at https://backstage.jimdex.net/docs/default/component/wonderland2-k8s-operator/How-To/Debug/ for troubleshooting"' ERR
+trap 'rc=$?; log "$rc: There was a problem. Please take a look at https://backstage.jimdex.net/docs/default/component/wonderland2-k8s-operator/How-To/Debug/ for troubleshooting"; exit $rc' ERR
 
 if [ $# -lt 6 ]; then
   log "Not enough arguments"


### PR DESCRIPTION
This change fixes the scenarios when gh action workflow passes even
when there was a failure in one of the workflow steps that used
this action.

closes https://jimplan.atlassian.net/browse/WL-1324
refer
- https://github.com/Jimdo/financial-services/runs/5688000516?check_suite_focus=true
- https://github.com/Jimdo/financial-services/runs/5688000516?check_suite_focus=true#step:11:18

- [x] Local Testing
```sh
$ ./entrypoint.sh ab ab ds bas bas as
Fri Mar 25 08:34:04 UTC 2022 Setting WONDERLAND_GITHUB_TOKEN
Fri Mar 25 08:34:04 UTC 2022 Setting ssh key
mkdir: /root/.ssh/: Read-only file system
Fri Mar 25 08:34:04 UTC 2022 1: There was a problem. Please take a look at https://backstage.jimdex.net/docs/default/component/wonderland2-k8s-operator/How-To/Debug/ for troubleshooting

$ echo $?
1
```

Signed-off-by: AmitKumarDas <amit.das@jimdo.com>