### PR TITLE
WL-1338 describe release process and reference version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # wonderland2-deploy-github-action
 
-A GitHub action to deploy or delete services to Wonderland2
+A GitHub action to deploy or delete services to Wonderland2.
+
+*For infos how to release a new version have a look at [How to
+release][htr]*
+
+[htr]: #how-to-release
 
 ## How to use it
 
@@ -10,7 +15,7 @@ A GitHub action to deploy or delete services to Wonderland2
 
 ```yaml
 - name: Deploy to Wonderland 2
-  uses: Jimdo/wonderland2-deploy-github-action@main
+  uses: Jimdo/wonderland2-deploy-github-action@v0.1.0
   with:
     token: ${{ secrets.WONDERLAND_CI_GITHUB_TOKEN }}
     bastion_key: ${{ secrets.WONDERLAND_CI_SSH_KEY }}
@@ -39,3 +44,16 @@ The Wonderland 2 manifest file (default: **wonderland2.yaml**)
 ### delete
 
 set this to `"true"` if you intend to delete the service instead of deploying it 
+
+## How to release
+
+- Choose a new version number
+- Update README example with new version number
+- Go to [draft a new release][dnr]
+- Create the new version number
+- Put the version number in the title
+- Press `Auto-generate release notes`
+- Press `Publish release`
+- Done
+
+[dnr]: https://github.com/Jimdo/wonderland2-deploy-github-action/releases/new


### PR DESCRIPTION
We want to switch to a release based model. So let us describe the
release process and reference the current version in the README as
example.

A release based approach allows us to adapt the parameters more easily
without breaking others uses. We therefore created a new default branch
named `release` and stopped changing `main` to avoid breaking current
users expectations.